### PR TITLE
fixed issue#3 by stripping whitespaces

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,7 +28,13 @@ def prepare_data(dataframe: pd.DataFrame, feature_columns: str, target_columns: 
     Retrieves the data in the columns required by the user.
     """
     f_headers = feature_columns.split(";")
+    for i in range(len(f_headers)):
+        f_headers[i] = f_headers[i].strip()
+
     t_headers = target_columns.split(";")
+    for i in range(len(t_headers)):
+        t_headers[i] = t_headers[i].strip()
+        
     X = dataframe[f_headers]
     y = dataframe[t_headers]  
     return X, y 


### PR DESCRIPTION
Le problème décrit dans la issue #3 a été résolu. Le problème apparaissait quand l'utilisateur ajoutait des espaces autour des points-virgules lorsqu'il entrait le nom des colonnes à utiliser dans l'interface (e.g. "colonne_1; colonne_2" .

Pour corriger ça, on élimine maintenant les espaces vides avant et après chaque nom de colonne après avoir splitté le texte entré par l'utilisateur en fonction des points-virgules.